### PR TITLE
[Feature/49] Member 엔티티 분리

### DIFF
--- a/core/core-api/src/main/kotlin/io/say/better/domain/member/application/MemberFacade.kt
+++ b/core/core-api/src/main/kotlin/io/say/better/domain/member/application/MemberFacade.kt
@@ -5,6 +5,8 @@ import io.say.better.domain.member.application.impl.MemberService
 import io.say.better.domain.member.exception.MemberException
 import io.say.better.global.common.code.status.ErrorStatus
 import io.say.better.global.utils.CodeUtil
+import io.say.better.storage.mysql.domain.entity.Educator
+import io.say.better.storage.mysql.domain.entity.Learner
 import io.say.better.storage.redis.RedisUtil
 import lombok.RequiredArgsConstructor
 import lombok.extern.slf4j.Slf4j
@@ -14,10 +16,10 @@ import org.springframework.stereotype.Component
 @Component
 @RequiredArgsConstructor
 class MemberFacade(
-        private val connectService: ConnectService,
-        private val memberService: MemberService,
-        private val codeUtil: CodeUtil,
-        private val redisUtil: RedisUtil
+    private val connectService: ConnectService,
+    private val memberService: MemberService,
+    private val codeUtil: CodeUtil,
+    private val redisUtil: RedisUtil
 ) {
 
     fun createConnectCode(): String {
@@ -30,12 +32,12 @@ class MemberFacade(
 
     fun connect(code: String?) {
         val email = redisUtil!!.getData(code)
-                ?: throw MemberException(ErrorStatus.CONNECT_CODE_NOT_VALID)
+            ?: throw MemberException(ErrorStatus.CONNECT_CODE_NOT_VALID)
 
         redisUtil.deleteData(code)
 
-        val educator = memberService!!.currentMember()
-        val learner = memberService.getMember(email)
+        val educator = memberService!!.currentMember() as Educator
+        val learner = memberService.getMember(email) as Learner
         connectService!!.connect(educator, learner)
     }
 }

--- a/core/core-api/src/main/kotlin/io/say/better/domain/member/application/converter/ConnectConverter.kt
+++ b/core/core-api/src/main/kotlin/io/say/better/domain/member/application/converter/ConnectConverter.kt
@@ -1,7 +1,8 @@
 package io.say.better.domain.member.application.converter
 
 import io.say.better.storage.mysql.domain.entity.Connect
-import io.say.better.storage.mysql.domain.entity.Member
+import io.say.better.storage.mysql.domain.entity.Educator
+import io.say.better.storage.mysql.domain.entity.Learner
 
 class ConnectConverter private constructor() {
     init {
@@ -9,11 +10,11 @@ class ConnectConverter private constructor() {
     }
 
     companion object {
-        fun toConnect(educator: Member?, learner: Member?): Connect {
+        fun toConnect(educator: Educator?, learner: Learner?): Connect {
             return Connect.builder()
-                    .educator(educator)
-                    .learner(learner)
-                    .build()
+                .educator(educator)
+                .learner(learner)
+                .build()
         }
     }
 }

--- a/core/core-api/src/main/kotlin/io/say/better/domain/member/application/converter/EducatorConverter.kt
+++ b/core/core-api/src/main/kotlin/io/say/better/domain/member/application/converter/EducatorConverter.kt
@@ -1,25 +1,23 @@
 package io.say.better.domain.member.application.converter
 
 import io.say.better.core.enums.Provider
-import io.say.better.core.enums.RoleType
-import io.say.better.storage.mysql.domain.entity.Member
+import io.say.better.storage.mysql.domain.entity.Educator
 
-class MemberConverter private constructor() {
+class EducatorConverter private constructor() {
     init {
         throw IllegalStateException("Utility class")
     }
 
     companion object {
-        fun toMember(
+        fun toEducator(
                 email: String?,
                 birthDate: String?,
-                role: RoleType?,
                 provider: Provider?,
                 providerId: String?,
                 loginId: String?,
                 name: String?
-        ): Member {
-            return Member.createMember(email, birthDate, role, provider, providerId, loginId, name)
+        ): Educator {
+            return Educator.createEducator(email, birthDate, provider, providerId, loginId, name)
         }
     }
 }

--- a/core/core-api/src/main/kotlin/io/say/better/domain/member/application/converter/LearnerConverter.kt
+++ b/core/core-api/src/main/kotlin/io/say/better/domain/member/application/converter/LearnerConverter.kt
@@ -1,0 +1,23 @@
+package io.say.better.domain.member.application.converter
+
+import io.say.better.core.enums.Provider
+import io.say.better.storage.mysql.domain.entity.Learner
+
+class LearnerConverter private constructor() {
+    init {
+        throw IllegalStateException("Utility class")
+    }
+
+    companion object {
+        fun toLearner(
+            email: String?,
+            birthDate: String?,
+            provider: Provider?,
+            providerId: String?,
+            loginId: String?,
+            name: String?
+        ): Learner {
+            return Learner.createLearner(email, birthDate, provider, providerId, loginId, name)
+        }
+    }
+}

--- a/core/core-api/src/main/kotlin/io/say/better/domain/member/application/impl/ConnectService.kt
+++ b/core/core-api/src/main/kotlin/io/say/better/domain/member/application/impl/ConnectService.kt
@@ -3,7 +3,8 @@ package io.say.better.domain.member.application.impl
 import io.say.better.domain.member.application.converter.ConnectConverter
 import io.say.better.storage.mysql.dao.repository.ConnectReadRepository
 import io.say.better.storage.mysql.dao.repository.ConnectWriteRepository
-import io.say.better.storage.mysql.domain.entity.Member
+import io.say.better.storage.mysql.domain.entity.Educator
+import io.say.better.storage.mysql.domain.entity.Learner
 import lombok.RequiredArgsConstructor
 import lombok.extern.slf4j.Slf4j
 import org.springframework.stereotype.Service
@@ -16,7 +17,7 @@ class ConnectService(
     private val connectWriteRepository: ConnectWriteRepository
 ) {
 
-    fun connect(educator: Member?, learner: Member?) {
+    fun connect(educator: Educator?, learner: Learner?) {
         val newConnect = ConnectConverter.toConnect(educator, learner)
         connectWriteRepository!!.save(newConnect)
     }

--- a/core/core-api/src/main/kotlin/io/say/better/domain/solution/application/SolutionFacade.kt
+++ b/core/core-api/src/main/kotlin/io/say/better/domain/solution/application/SolutionFacade.kt
@@ -11,6 +11,7 @@ import io.say.better.domain.solution.ui.dto.SolutionRequest.CreateSolution
 import io.say.better.domain.symbol.application.impl.SymbolService
 import io.say.better.global.advice.Tx
 import io.say.better.global.config.logger.logger
+import io.say.better.storage.mysql.domain.entity.Educator
 import io.say.better.storage.mysql.domain.entity.SolutionSymbol
 import io.say.better.storage.mysql.domain.entity.Symbol
 import lombok.extern.slf4j.Slf4j
@@ -19,11 +20,11 @@ import org.springframework.stereotype.Component
 @Slf4j
 @Component
 class SolutionFacade (
-        private val solutionService: SolutionService,
-        private val solutionSymbolService: SolutionSymbolService,
-        private val memberService: MemberService,
-        private val symbolService: SymbolService,
-        private val recommendClient: RecommendClient,
+    private val solutionService: SolutionService,
+    private val solutionSymbolService: SolutionSymbolService,
+    private val memberService: MemberService,
+    private val symbolService: SymbolService,
+    private val recommendClient: RecommendClient,
 ) {
 
     private val log = logger()
@@ -40,7 +41,7 @@ class SolutionFacade (
     }
 
     fun createSolution(request: CreateSolution) = Tx.writeable {
-        val member = memberService.currentMember()
+        val member = memberService.currentMember() as Educator
         val newSolution = SolutionConverter.toSolution(request, member)
         val savedSolution = solutionService.createSolution(newSolution)
 

--- a/core/core-api/src/main/kotlin/io/say/better/domain/solution/application/converter/SolutionConverter.kt
+++ b/core/core-api/src/main/kotlin/io/say/better/domain/solution/application/converter/SolutionConverter.kt
@@ -1,7 +1,7 @@
 package io.say.better.domain.solution.application.converter
 
 import io.say.better.domain.solution.ui.dto.SolutionRequest.CreateSolution
-import io.say.better.storage.mysql.domain.entity.Member
+import io.say.better.storage.mysql.domain.entity.Educator
 import io.say.better.storage.mysql.domain.entity.Solution
 
 class SolutionConverter private constructor() {
@@ -10,13 +10,16 @@ class SolutionConverter private constructor() {
     }
 
     companion object {
-        fun toSolution(request: CreateSolution, member: Member?): Solution {
+        fun toSolution(request: CreateSolution, educator: Educator?): Solution {
             return Solution.builder()
-                    .writer(member)
-                    .title(request.title)
-                    .commOptTimes(request.commOptTimes)
-                    .commOptCnt(request.commOptCnt)
-                    .build()
+                .writer(educator)
+                .title(request.title)
+                .baselineSessionTime(request.baselineSessionTime)
+                .interCompleteThresh(request.interCompleteThresh)
+                .interMaintainTerm(request.interMaintainTerm)
+                .commOptTimes(request.commOptTimes)
+                .commOptCnt(request.commOptCnt)
+                .build()
         }
     }
 }

--- a/core/core-api/src/main/kotlin/io/say/better/global/auth/CustomOAuth2User.kt
+++ b/core/core-api/src/main/kotlin/io/say/better/global/auth/CustomOAuth2User.kt
@@ -1,6 +1,5 @@
 package io.say.better.global.auth
 
-import io.say.better.core.enums.RoleType
 import org.springframework.security.core.GrantedAuthority
 import org.springframework.security.oauth2.core.user.DefaultOAuth2User
 
@@ -12,7 +11,6 @@ data class CustomOAuth2User(
     val attributes: Map<String, Any>,
     val nameAttributeKey: String,
     val email: String,
-    val role: RoleType
 ) : DefaultOAuth2User(authorities, attributes, nameAttributeKey) {
 
     override fun equals(other: Any?): Boolean {
@@ -20,15 +18,12 @@ data class CustomOAuth2User(
         if ((other == null) || (javaClass != other.javaClass) || super.equals(other).not()) return false
 
         val that = other as CustomOAuth2User
-
-        if (email != that.email) return false
-        return role == that.role
+        return email == that.email
     }
 
     override fun hashCode(): Int {
         var result = super.hashCode()
         result = 31 * result + email.hashCode()
-        result = 31 * result + role.hashCode()
         return result
     }
 }

--- a/core/core-api/src/main/kotlin/io/say/better/global/auth/OAuthAttributes.kt
+++ b/core/core-api/src/main/kotlin/io/say/better/global/auth/OAuthAttributes.kt
@@ -1,32 +1,52 @@
 package io.say.better.global.auth
 
 import io.say.better.core.enums.Provider
-import io.say.better.core.enums.RoleType
-import io.say.better.domain.member.application.converter.MemberConverter
+import io.say.better.domain.member.application.converter.EducatorConverter
+import io.say.better.domain.member.application.converter.LearnerConverter
 import io.say.better.global.auth.exception.AuthException
 import io.say.better.global.auth.info.GoogleOAuth2UserInfo
 import io.say.better.global.auth.info.OAuth2UserInfo
 import io.say.better.global.common.code.status.ErrorStatus
-import io.say.better.storage.mysql.domain.entity.Member
+import io.say.better.storage.mysql.domain.entity.Educator
+import io.say.better.storage.mysql.domain.entity.Learner
 
 data class OAuthAttributes(
     val key: String, // OAuth2 로그인 시 키가 되는 필드값
     val userInfo: OAuth2UserInfo // OAuth2 로그인 유저 정보
 ) {
     /**
-     * OAuth2User의 attribute를 담은 Map을 Member로 변환
+     * OAuth2User의 attribute를 담은 Map을 Educator로 변환
      *
      * @param provider       소셜 로그인 제공자 (구글)
      * @param oauth2UserInfo 소셜 로그인 유저 정보
-     * @return Member
+     * @return Educator
      */
-    fun toEntity(provider: Provider, oauth2UserInfo: OAuth2UserInfo): Member {
+    fun toEducatorEntity(provider: Provider, oauth2UserInfo: OAuth2UserInfo): Educator {
         val loginId = oauth2UserInfo.provider + "_" + oauth2UserInfo.providerId
 
-        return MemberConverter.toMember(
+        return EducatorConverter.toEducator(
             email = oauth2UserInfo.email,
             birthDate = null,
-            role = RoleType.NONE,
+            provider = provider,
+            providerId = oauth2UserInfo.providerId,
+            loginId = loginId,
+            name = oauth2UserInfo.name
+        )
+    }
+
+    /**
+     * OAuth2User의 attribute를 담은 Map을 Learner로 변환
+     *
+     * @param provider       소셜 로그인 제공자 (구글)
+     * @param oauth2UserInfo 소셜 로그인 유저 정보
+     * @return Educator
+     */
+    fun toLearnerEntity(provider: Provider, oauth2UserInfo: OAuth2UserInfo): Learner {
+        val loginId = oauth2UserInfo.provider + "_" + oauth2UserInfo.providerId
+
+        return LearnerConverter.toLearner(
+            email = oauth2UserInfo.email,
+            birthDate = null,
             provider = provider,
             providerId = oauth2UserInfo.providerId,
             loginId = loginId,

--- a/core/core-api/src/main/kotlin/io/say/better/global/config/security/SecurityConfig.kt
+++ b/core/core-api/src/main/kotlin/io/say/better/global/config/security/SecurityConfig.kt
@@ -8,7 +8,8 @@ import io.say.better.global.config.properties.JwtProperties
 import io.say.better.global.config.web.CorsConfig
 import io.say.better.global.jwt.filter.JwtAuthenticationProcessingFilter
 import io.say.better.global.jwt.service.JwtService
-import io.say.better.storage.mysql.dao.repository.MemberReadRepository
+import io.say.better.storage.mysql.dao.repository.EducatorReadRepository
+import io.say.better.storage.mysql.dao.repository.LearnerReadRepository
 import io.say.better.storage.redis.RedisUtil
 import lombok.RequiredArgsConstructor
 import org.springframework.boot.autoconfigure.security.servlet.PathRequest
@@ -26,7 +27,8 @@ open class SecurityConfig(
     private val redisUtil: RedisUtil,
     private val jwtService: JwtService,
     private val jwtProperties: JwtProperties,
-    private val memberReadRepository: MemberReadRepository,
+    private val educatorReadRepository: EducatorReadRepository,
+    private val learnerReadRepository: LearnerReadRepository,
     private val customOAuth2UserService: CustomOAuth2UserService,
     private val OAuth2LoginSuccessHandler: OAuth2LoginSuccessHandler,
     private val OAuth2LoginFailureHandler: OAuth2LoginFailureHandler
@@ -94,7 +96,7 @@ open class SecurityConfig(
     @Bean
     open fun jwtAuthenticationProcessingFilter(): JwtAuthenticationProcessingFilter {
         return JwtAuthenticationProcessingFilter(
-            memberReadRepository, jwtProperties, jwtService, redisUtil
+            educatorReadRepository, learnerReadRepository, jwtProperties, jwtService, redisUtil
         )
     }
 }

--- a/storage/storage-mysql/src/main/java/io/say/better/storage/mysql/dao/repository/EducatorReadRepository.java
+++ b/storage/storage-mysql/src/main/java/io/say/better/storage/mysql/dao/repository/EducatorReadRepository.java
@@ -1,0 +1,14 @@
+package io.say.better.storage.mysql.dao.repository;
+
+import io.say.better.core.enums.Provider;
+import io.say.better.storage.mysql.domain.entity.Educator;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface EducatorReadRepository extends JpaRepository<Educator, Long>, MemberReadRepository<Educator> {
+
+	Optional<Educator> findByProviderAndLoginId(Provider provider, String loginId);
+
+	Optional<Educator> findByEmail(String email);
+}

--- a/storage/storage-mysql/src/main/java/io/say/better/storage/mysql/dao/repository/EducatorWriteRepository.java
+++ b/storage/storage-mysql/src/main/java/io/say/better/storage/mysql/dao/repository/EducatorWriteRepository.java
@@ -1,0 +1,7 @@
+package io.say.better.storage.mysql.dao.repository;
+
+import io.say.better.storage.mysql.domain.entity.Educator;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface EducatorWriteRepository extends JpaRepository<Educator, Long> {
+}

--- a/storage/storage-mysql/src/main/java/io/say/better/storage/mysql/dao/repository/LearnerReadRepository.java
+++ b/storage/storage-mysql/src/main/java/io/say/better/storage/mysql/dao/repository/LearnerReadRepository.java
@@ -1,0 +1,14 @@
+package io.say.better.storage.mysql.dao.repository;
+
+import io.say.better.core.enums.Provider;
+import io.say.better.storage.mysql.domain.entity.Learner;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface LearnerReadRepository extends JpaRepository<Learner, Long>, MemberReadRepository<Learner> {
+
+	Optional<Learner> findByProviderAndLoginId(Provider provider, String loginId);
+
+	Optional<Learner> findByEmail(String email);
+}

--- a/storage/storage-mysql/src/main/java/io/say/better/storage/mysql/dao/repository/LearnerWriteRepository.java
+++ b/storage/storage-mysql/src/main/java/io/say/better/storage/mysql/dao/repository/LearnerWriteRepository.java
@@ -1,0 +1,7 @@
+package io.say.better.storage.mysql.dao.repository;
+
+import io.say.better.storage.mysql.domain.entity.Learner;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface LearnerWriteRepository extends JpaRepository<Learner, Long> {
+}

--- a/storage/storage-mysql/src/main/java/io/say/better/storage/mysql/dao/repository/MemberReadRepository.java
+++ b/storage/storage-mysql/src/main/java/io/say/better/storage/mysql/dao/repository/MemberReadRepository.java
@@ -1,15 +1,10 @@
 package io.say.better.storage.mysql.dao.repository;
 
-import java.util.Optional;
-
-import org.springframework.data.jpa.repository.JpaRepository;
-
-import io.say.better.storage.mysql.domain.entity.Member;
 import io.say.better.core.enums.Provider;
 
-public interface MemberReadRepository extends JpaRepository<Member, Long> {
+import java.util.Optional;
 
-	Optional<Member> findByProviderAndLoginId(Provider provider, String loginId);
-
-	Optional<Member> findByEmail(String email);
+public interface MemberReadRepository<T> {
+	Optional<T> findByProviderAndLoginId(Provider provider, String loginId);
+	Optional<T> findByEmail(String email);
 }

--- a/storage/storage-mysql/src/main/java/io/say/better/storage/mysql/dao/repository/MemberWriteRepository.java
+++ b/storage/storage-mysql/src/main/java/io/say/better/storage/mysql/dao/repository/MemberWriteRepository.java
@@ -1,8 +1,0 @@
-package io.say.better.storage.mysql.dao.repository;
-
-import org.springframework.data.jpa.repository.JpaRepository;
-
-import io.say.better.storage.mysql.domain.entity.Member;
-
-public interface MemberWriteRepository extends JpaRepository<Member, Long> {
-}

--- a/storage/storage-mysql/src/main/java/io/say/better/storage/mysql/domain/entity/Connect.java
+++ b/storage/storage-mysql/src/main/java/io/say/better/storage/mysql/domain/entity/Connect.java
@@ -1,7 +1,5 @@
 package io.say.better.storage.mysql.domain.entity;
 
-import io.say.better.storage.mysql.domain.entity.BaseTimeEntity;
-import io.say.better.storage.mysql.domain.entity.Member;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.FetchType;
@@ -29,14 +27,14 @@ public class Connect extends BaseTimeEntity {
 
 	@ManyToOne(fetch = FetchType.LAZY)
 	@JoinColumn(name = "educator_id")
-	private Member educator;
+	private Educator educator;
 
 	@ManyToOne(fetch = FetchType.LAZY)
 	@JoinColumn(name = "learner_id")
-	private Member learner;
+	private Learner learner;
 
 	@Builder
-	public Connect(Member educator, Member learner) {
+	public Connect(Educator educator, Learner learner) {
 		this.educator = educator;
 		this.learner = learner;
 	}

--- a/storage/storage-mysql/src/main/java/io/say/better/storage/mysql/domain/entity/Educator.java
+++ b/storage/storage-mysql/src/main/java/io/say/better/storage/mysql/domain/entity/Educator.java
@@ -1,0 +1,53 @@
+package io.say.better.storage.mysql.domain.entity;
+
+import io.say.better.core.enums.Provider;
+import io.say.better.core.enums.RoleType;
+import io.say.better.core.enums.Status;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Getter
+@Entity(name = "EDUCATOR")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Educator extends Member {
+
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	@Column(name = "educator_id")
+	private Long educatorId;
+
+	@Builder
+	private Educator(
+			final String email,
+			final String birthDate,
+			final Provider provider,
+			final String providerId,
+			final String loginId,
+			final String name
+	) {
+		this.status = Status.ACTIVE;
+		this.email = email;
+		this.birthDate = birthDate;
+		this.role = RoleType.EDUCATOR;
+		this.provider = provider;
+		this.providerId = providerId;
+		this.loginId = loginId;
+		this.name = name;
+	}
+
+	public static Educator createEducator(
+			final String email,
+			final String birthDate,
+			final Provider provider,
+			final String providerId,
+			final String loginId,
+			final String name
+	) {
+		return new Educator(email, birthDate, provider, providerId, loginId, name);
+	}
+}

--- a/storage/storage-mysql/src/main/java/io/say/better/storage/mysql/domain/entity/Learner.java
+++ b/storage/storage-mysql/src/main/java/io/say/better/storage/mysql/domain/entity/Learner.java
@@ -1,0 +1,53 @@
+package io.say.better.storage.mysql.domain.entity;
+
+import io.say.better.core.enums.Provider;
+import io.say.better.core.enums.RoleType;
+import io.say.better.core.enums.Status;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Getter
+@Entity(name = "LEARNER")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Learner extends Member {
+
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	@Column(name = "learner_id")
+	private Long learnerId;
+
+	@Builder
+	private Learner(
+			final String email,
+			final String birthDate,
+			final Provider provider,
+			final String providerId,
+			final String loginId,
+			final String name
+	) {
+		this.status = Status.ACTIVE;
+		this.email = email;
+		this.birthDate = birthDate;
+        this.role = RoleType.LEARNER;
+		this.provider = provider;
+		this.providerId = providerId;
+		this.loginId = loginId;
+		this.name = name;
+	}
+
+	public static Learner createLearner(
+			final String email,
+			final String birthDate,
+			final Provider provider,
+			final String providerId,
+			final String loginId,
+			final String name
+	) {
+		return new Learner(email, birthDate, provider, providerId, loginId, name);
+	}
+}

--- a/storage/storage-mysql/src/main/java/io/say/better/storage/mysql/domain/entity/Member.java
+++ b/storage/storage-mysql/src/main/java/io/say/better/storage/mysql/domain/entity/Member.java
@@ -4,89 +4,44 @@ import io.say.better.core.enums.Provider;
 import io.say.better.core.enums.RoleType;
 import io.say.better.core.enums.Status;
 import jakarta.persistence.Column;
-import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.GenerationType;
-import jakarta.persistence.Id;
+import jakarta.persistence.MappedSuperclass;
 import lombok.AccessLevel;
-import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
+import lombok.experimental.SuperBuilder;
 
-@Slf4j
 @Getter
-@Entity(name = "MEMBER")
+@SuperBuilder
+@MappedSuperclass
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class Member extends BaseTimeEntity {
-
-	@Id
-	@GeneratedValue(strategy = GenerationType.IDENTITY)
-	@Column(name = "member_id")
-	private Long memberId;
+public abstract class Member extends BaseTimeEntity {
 
 	@Enumerated(EnumType.STRING)
 	@Column(name = "status", nullable = false, length = 20)
-	private Status status;
+	Status status;
 
 	@Column(name = "email", nullable = false, length = 100)
-	private String email;
+	String email;
 
 	@Column(name = "birth_date")
-	private String birthDate;
+	String birthDate;
 
 	@Enumerated(EnumType.STRING)
 	@Column(name = "role", nullable = false, length = 20)
-	private RoleType role;
+	RoleType role;
 
 	@Enumerated(EnumType.STRING)
 	@Column(name = "provider", nullable = false, length = 20)
-	private Provider provider;
+	Provider provider;
 
 	@Column(name = "provider_id", nullable = false)
-	private String providerId;
+	String providerId;
 
 	@Column(name = "login_id", nullable = false)
-	private String loginId;
+	String loginId;
 
 	@Column(name = "name", nullable = false, length = 100)
-	private String name;
-
-	@Builder
-	private Member(
-			final String email,
-			final String birthDate,
-			final RoleType role,
-			final Provider provider,
-			final String providerId,
-			final String loginId,
-			final String name
-	) {
-		this.status = Status.ACTIVE;
-		this.email = email;
-		this.birthDate = birthDate;
-		this.role = role;
-		this.provider = provider;
-		this.providerId = providerId;
-		this.loginId = loginId;
-		this.name = name;
-	}
-
-	public static Member createMember(
-			final String email,
-			final String birthDate,
-			final RoleType role,
-			final Provider provider,
-			final String providerId,
-			final String loginId,
-			final String name
-	) {
-		return new Member(email, birthDate, role, provider, providerId, loginId, name);
-	}
-
-	public void assignRole(RoleType role) {
-		this.role = role;
-	}
+	String name;
 }

--- a/storage/storage-mysql/src/main/java/io/say/better/storage/mysql/domain/entity/Solution.java
+++ b/storage/storage-mysql/src/main/java/io/say/better/storage/mysql/domain/entity/Solution.java
@@ -1,8 +1,16 @@
 package io.say.better.storage.mysql.domain.entity;
 
 import io.say.better.core.enums.Status;
-import io.say.better.storage.mysql.domain.constant.ProgressState;
-import jakarta.persistence.*;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -23,26 +31,31 @@ public class Solution extends BaseTimeEntity {
 	@Column(name = "solution_id")
 	private Long solutionId;
 
-    @Enumerated(EnumType.STRING)
-    @Column(name = "now_state", nullable = false)
-    private ProgressState nowState;
-
-    @Column(name = "educationGoal", nullable = false) // length 255
-    private String educationGoal;
-
-    @Column(name = "description", nullable = false) // length 255
-    private String description;
-
 	@ManyToOne(fetch = FetchType.LAZY)
 	@JoinColumn(name = "writer_id", nullable = false)
-	private Member writer;
-
-    @OneToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "learner_id")
-    private Member learner;
+	private Educator writer;
 
 	@Column(name = "title", nullable = false, length = 100)
 	private String title;
+
+	@Column(name = "learner_link_cnt", nullable = false, columnDefinition = "int default 0")
+	private Integer learnerLinkCnt;
+
+	// 기초선 회기 수
+	@Column(name = "baseline_session_time", nullable = false, columnDefinition = "int default 0")
+	private Integer baselineSessionTime;
+
+	// 중재 완료하기 위한 장반응률 임계값
+	@Column(name = "inter_complete_thresh", nullable = false, columnDefinition = "double default 0.0")
+	private Double interCompleteThresh;
+
+	// 중재 ~ 유지 사이의 기간
+	@Column(name = "inter_maintain_term", nullable = false, columnDefinition = "int default 0")
+	private Integer interMaintainTerm;
+
+	// 유지 회기 수
+	@Column(name = "maintain_session_time", nullable = false, columnDefinition = "int default 0")
+	private Integer maintainSessionTime;
 
 	// 회기당 의사소통 기회 부여 횟수
 	@Column(name = "comm_opt_times", nullable = false, columnDefinition = "int default 0")


### PR DESCRIPTION
## Type of change
<!-- 작업의 종류를 선택해주세요. -->
- [x] Feature : 새로운 기능 추가
- [ ] Bug fix : 버그 수정
- [ ] Refactor : 코드 리팩토링 작업
- [ ] Document : 문서작업
- [ ] Test : 테스트 코드 작성 및 테스트 작업
- [ ] Style : 코드 스타일 및 포맷팅 작업
- [ ] CI/CD : CI/CD 작업 수정
- [ ] Chore : 패키지 매니저, 라이브러리 업데이트 등의 작업

## PR Desciption

> 변경 사항 설명

- Member 엔티티를 Educator, Learner 엔티티로 분리
- 엔티티 변경에 따른 타 파일 수정

## Requirements for Reviewer
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?

- 기존 Member 클래스의 공통적인 영역(이메일, 생년월일 등)을 abstract class로 두고 상속받는 방식으로 구현했는데, 다음 사항을 중점적으로 확인해주시면 좋을 것 같습니다.
  - 구현 방식이 적절한지
  - 기존 Member 클래스를 이용하는 다른 클래스에서 타입이 적절하게 변경 및 적용되었는지

## 관련 이슈

- close #49
