### PR TITLE
[Feature/91] Symbol 추천 API

### DIFF
--- a/clients/client-api/src/main/kotlin/io/say/better/client/symbol/converter/RecommendResultConverter.kt
+++ b/clients/client-api/src/main/kotlin/io/say/better/client/symbol/converter/RecommendResultConverter.kt
@@ -15,7 +15,7 @@ class RecommendResultConverter private constructor() {
 
         private fun getSymbols(recommend: RecommendResponse.SymbolRecommend): List<String> {
             val symbolString = recommend.symbol
-            val symbols = symbolString.split(",".toRegex()).dropLastWhile { it.isEmpty() }.toTypedArray()
+            val symbols = symbolString.split("\\s+".toRegex()).dropLastWhile { it.isEmpty() }.toTypedArray()
             return ArrayList(listOf(*symbols))
         }
     }

--- a/storage/storage-mysql-kt/src/main/kotlin/io/say/better/storage/mysql/domain/entity/Symbol.kt
+++ b/storage/storage-mysql-kt/src/main/kotlin/io/say/better/storage/mysql/domain/entity/Symbol.kt
@@ -20,4 +20,21 @@ class Symbol(
     @Enumerated(EnumType.STRING)
     @Column(name = "type", nullable = false, length = 20)
     private val type: SymbolType,
-)
+) {
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (other == null || javaClass != other.javaClass) {
+            return false
+        }
+
+        val that = other as Symbol
+        return title == that.title && imgUrl == that.imgUrl && type == that.type
+    }
+
+    override fun hashCode(): Int {
+        var result = title.hashCode()
+        result = 31 * result + imgUrl.hashCode()
+        result = 31 * result + type.hashCode()
+        return result
+    }
+}

--- a/tests/api-docs/src/test/kotlin/io/say/better/test/api/solution/SolutionInfoControllerTest.kt
+++ b/tests/api-docs/src/test/kotlin/io/say/better/test/api/solution/SolutionInfoControllerTest.kt
@@ -158,4 +158,31 @@ class SolutionInfoControllerTest
                 .andExpect(MockMvcResultMatchers.jsonPath("$.message", SuccessStatus.OK.message).exists())
                 .andExpect(MockMvcResultMatchers.jsonPath("$.result").doesNotExist())
         }
+
+        @Test
+        @DisplayName("symbol 추천 결과 리스트를 반환한다. 추천 결과가 없을 경우 빈 리스트를 반환한다.")
+        @WithMockUser
+        fun recommendSymbolTest() {
+            // Given
+            val word = "testWord"
+            val recommendList = arrayListOf(
+                SolutionResponse.SymbolInfo("testDescription1", "testImg1.jpg"),
+                SolutionResponse.SymbolInfo("testDescription2", "testImg2.jpg")
+            )
+            BDDMockito.given(solutionFacade.recommendSymbol(word)).willReturn(SolutionResponse.SymbolList(word, recommendList))
+
+            // When
+            val actions: ResultActions =
+                mockMvc.perform(
+                    RestDocumentationRequestBuilders.get("/api/solution/symbol/recommend/{name}", word)
+                        .with(SecurityMockMvcRequestPostProcessors.csrf()),
+                )
+
+            // Then
+            actions.andExpect(MockMvcResultMatchers.status().isOk)
+                .andExpect(MockMvcResultMatchers.jsonPath("$.isSuccess", true).exists())
+                .andExpect(MockMvcResultMatchers.jsonPath("$.code", SuccessStatus.OK.code).exists())
+                .andExpect(MockMvcResultMatchers.jsonPath("$.message", SuccessStatus.OK.message).exists())
+                .andExpect(MockMvcResultMatchers.jsonPath("$.result", List::class).exists())
+        }
     }

--- a/tests/api-docs/src/test/kotlin/io/say/better/test/api/symbol/SymbolRepositoryTest.kt
+++ b/tests/api-docs/src/test/kotlin/io/say/better/test/api/symbol/SymbolRepositoryTest.kt
@@ -38,7 +38,7 @@ class SymbolRepositoryTest
         val symbolList: List<Symbol> = symbolReadRepository.findByTitleIn(symbolNames)
 
         // Then
-        Assertions.assertThat(equals(symbols, symbolList)).isEqualTo(true)
+        Assertions.assertThat(compare(symbols, symbolList)).isEqualTo(true)
     }
 
     @Nested
@@ -62,7 +62,7 @@ class SymbolRepositoryTest
 
             // Then
             Assertions.assertThat(
-                equals(
+                compare(
                     symbols.filter { it.title.contains(symbolNames) },
                     symbolList
                 )
@@ -87,7 +87,7 @@ class SymbolRepositoryTest
 
             // Then
             Assertions.assertThat(
-                equals(
+                compare(
                     symbols.filter { it.title.contains(symbolNames) },
                     symbolList
                 )
@@ -95,7 +95,7 @@ class SymbolRepositoryTest
         }
     }
 
-    private fun equals(
+    private fun compare(
         symbols: List<Symbol>,
         comparingSymbols: List<Symbol>
     ): Boolean {
@@ -104,10 +104,7 @@ class SymbolRepositoryTest
         }
 
         for (i in symbols.indices) {
-            if (
-                symbols[i].title != comparingSymbols[i].title ||
-                symbols[i].imgUrl != comparingSymbols[i].imgUrl
-            ) {
+            if (!symbols[i].equals(comparingSymbols[i])) {
                 return false
             }
         }

--- a/tests/api-docs/src/test/kotlin/io/say/better/test/api/symbol/SymbolRepositoryTest.kt
+++ b/tests/api-docs/src/test/kotlin/io/say/better/test/api/symbol/SymbolRepositoryTest.kt
@@ -1,0 +1,116 @@
+package io.say.better.test.api.symbol
+
+import io.say.better.storage.mysql.dao.repository.SymbolReadRepository
+import io.say.better.storage.mysql.dao.repository.SymbolWriteRepository
+import io.say.better.storage.mysql.domain.constant.SymbolType
+import io.say.better.storage.mysql.domain.entity.Symbol
+import org.assertj.core.api.Assertions
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest
+
+@DataJpaTest
+class SymbolRepositoryTest
+@Autowired constructor(
+    private val symbolReadRepository: SymbolReadRepository,
+    private val symbolWriteRepository: SymbolWriteRepository
+) {
+    @Test
+    @DisplayName("symbol 이름을 탐색한 결과 리스트를 반환한다. 검색 결과가 없을 경우 빈 리스트를 반환한다.")
+    fun getSymbolsByTitleInTest() {
+        // Given
+        val symbols: List<Symbol> = arrayListOf(
+            Symbol(1L, "testTitle1", "testUrl1", SymbolType.BASIC),
+            Symbol(2L, "testTitle2", "testUrl2", SymbolType.BASIC),
+            Symbol(3L, "testTitle3", "testUrl3", SymbolType.BASIC)
+        )
+        symbolWriteRepository.saveAll(symbols)
+
+        val symbolNames = arrayListOf(
+            "testTitle1",
+            "testTitle2",
+            "testTitle3"
+        )
+
+        // When
+        val symbolList: List<Symbol> = symbolReadRepository.findByTitleIn(symbolNames)
+
+        // Then
+        Assertions.assertThat(equals(symbols, symbolList)).isEqualTo(true)
+    }
+
+    @Nested
+    @DisplayName("symbol 이름을 탐색한 결과 리스트를 반환한다. 검색 결과가 없을 경우 빈 리스트를 반환한다.")
+    inner class SymbolsByTitleStartingWithTest {
+        @Test
+        @DisplayName("특정 문자열로 시작하는 symbol 이름을 탐색한 결과 리스트를 반환한다.")
+        fun getSymbolsSuccessTest() {
+            // Given
+            val symbols: List<Symbol> = arrayListOf(
+                Symbol(1L, "testTitle1", "testUrl1", SymbolType.BASIC),
+                Symbol(2L, "sampleTestTitle2", "testUrl2", SymbolType.BASIC),
+                Symbol(3L, "sampleTitle3", "testUrl3", SymbolType.BASIC)
+            )
+            symbolWriteRepository.saveAll(symbols)
+
+            val symbolNames = "test"
+
+            // When
+            val symbolList: List<Symbol> = symbolReadRepository.findByTitleStartingWith(symbolNames)
+
+            // Then
+            Assertions.assertThat(
+                equals(
+                    symbols.filter { it.title.contains(symbolNames) },
+                    symbolList
+                )
+            ).isEqualTo(true)
+        }
+
+        @Test
+        @DisplayName("symbol 이름에 특정 문자열이 포함되어 있어도 해당 문자열로 시작하지 않는 경우 검색 결과 리스트에 포함하지 않는다.")
+        fun getSymbolsFailTest() {
+            // Given
+            val symbols: List<Symbol> = arrayListOf(
+                Symbol(1L, "testTitle1", "testUrl1", SymbolType.BASIC),
+                Symbol(2L, "sampletestTitle2", "testUrl2", SymbolType.BASIC),
+                Symbol(3L, "sampleTitle3", "testUrl3", SymbolType.BASIC)
+            )
+            symbolWriteRepository.saveAll(symbols)
+
+            val symbolNames = "test"
+
+            // When
+            val symbolList: List<Symbol> = symbolReadRepository.findByTitleStartingWith(symbolNames)
+
+            // Then
+            Assertions.assertThat(
+                equals(
+                    symbols.filter { it.title.contains(symbolNames) },
+                    symbolList
+                )
+            ).isEqualTo(false)
+        }
+    }
+
+    private fun equals(
+        symbols: List<Symbol>,
+        comparingSymbols: List<Symbol>
+    ): Boolean {
+        if (symbols.size != comparingSymbols.size) {
+            return false
+        }
+
+        for (i in symbols.indices) {
+            if (
+                symbols[i].title != comparingSymbols[i].title ||
+                symbols[i].imgUrl != comparingSymbols[i].imgUrl
+            ) {
+                return false
+            }
+        }
+        return true
+    }
+}


### PR DESCRIPTION
## Type of change
<!-- 작업의 종류를 선택해주세요. -->
- [x] Feature : 새로운 기능 추가
- [x] Bug fix : 버그 수정
- [ ] Refactor : 코드 리팩토링 작업
- [ ] Document : 문서작업
- [x] Test : 테스트 코드 작성 및 테스트 작업
- [ ] Style : 코드 스타일 및 포맷팅 작업
- [ ] CI/CD : CI/CD 작업 수정
- [ ] Chore : 패키지 매니저, 라이브러리 업데이트 등의 작업

## PR Desciption

> 변경 사항 설명

- ML 서버 요청 결과 공백을 기준으로 단어가 구분됨을 확인, parsing 형식 수정
- 심볼 추천 컨트롤러 / 레포지토리 테스트 작성

## Requirements for Reviewer
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?

- Symbol 엔티티 클래스 내에 별도의 equals 메서드가 없어 임의로 레포지토리 테스트 클래스 내부에 작성을 해놓은 상태인데, 혹시 더 좋은 방법이 있을지 고민이 됩니다.

## 관련 이슈

- close #91
